### PR TITLE
Cleanup for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 local_note.md
-Gemfile.lock
+test/dump.rdb
+test/stdout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+from ruby:3.2
+RUN apt update && apt install -y redis && apt clean
+COPY . /app/
+WORKDIR /app
+RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ group :test do
   gem 'rake'
   gem 'json'
   gem 'timecop'
+  gem 'minitest'
   gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    resque-cleaner (0.4.1)
+      resque
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    connection_pool (2.4.0)
+    json (2.6.3)
+    minitest (5.18.0)
+    mono_logger (1.1.2)
+    multi_json (1.15.0)
+    mustermann (2.0.2)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.6.4)
+    rack-protection (2.2.4)
+      rack
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rake (13.0.6)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
+    redis-client (0.14.1)
+      connection_pool
+    redis-namespace (1.10.0)
+      redis (>= 4)
+    resque (2.5.0)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.6)
+      sinatra (>= 0.9.2)
+    ruby2_keywords (0.0.5)
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
+      rack (~> 2.2)
+      rack-protection (= 2.2.4)
+      tilt (~> 2.0)
+    tilt (2.1.0)
+    timecop (0.9.6)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  json
+  minitest
+  rack-test
+  rake
+  resque-cleaner!
+  timecop
+
+BUNDLED WITH
+   2.4.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  console:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: resque-cleaner-console
+    volumes:
+      - ".:/app"

--- a/resque-cleaner.gemspec
+++ b/resque-cleaner.gemspec
@@ -20,9 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "resque"
 
-  s.add_development_dependency "minitest", "~> 5.0"
-  s.add_development_dependency "rack-test", "~> 0.6.0"
-
   s.description = <<DESCRIPTION
     resque-cleaner maintains the cleanliness of failed jobs on Resque.
 DESCRIPTION

--- a/test/resque_cleaner_test.rb
+++ b/test/resque_cleaner_test.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 require 'time'
 describe "ResqueCleaner" do
   before do
-    Resque.redis.flushall
+    Resque.redis.redis.flushall
 
     @worker = Resque::Worker.new(:jobs,:jobs2)
 
@@ -155,7 +155,7 @@ describe "ResqueCleaner" do
     # with block
     ret = @cleaner.stats_by_date{|j| j['payload']['args']==['Jason']}
     assert_equal 2, ret['2009/03/13']
-    assert_equal nil, ret['2009/11/13']
+    assert_nil ret['2009/11/13']
     assert_equal 11, ret['2010/08/13']
   end
 

--- a/test/resque_web_test.rb
+++ b/test/resque_web_test.rb
@@ -12,7 +12,7 @@ class Minitest::Spec
 end
 
 def setup_some_failed_jobs
-  Resque.redis.flushall
+  Resque.redis.redis.flushall
 
   @worker = Resque::Worker.new(:jobs,:jobs2)
 
@@ -59,17 +59,17 @@ describe "resque-web" do
     assert last_response.body.include?('"BadJobWithSyntaxError"')
     assert last_response.body.include?('"BadJob"')
   end
-  
+
   it "#cleaner_list shows escaped XSS attempt" do
     get "/cleaner_list?t=%22%3e%3cscript%3ealert(document.cookie)%3c%2fscript%3e"
     assert last_response.body.include?('&quot;&gt;&lt;script&gt;alert(document.cookie)&lt;&#x2F;script&gt;')
   end
-  
+
   it '#cleaner_exec clears job' do
     post "/cleaner_exec", :action => "clear", :sha1 => Digest::SHA1.hexdigest(@cleaner.select[0].to_json)
     assert_equal 10, @cleaner.select.size
   end
-  
+
   it "#cleaner_dump should respond with success" do
     get "/cleaner_dump"
     assert last_response.ok?, last_response.errors


### PR DESCRIPTION
- Add a dockerfile for test env
- Make the gems for test install reliably
- Fix some deprecation warnings from redis-namespace
- Commit the Gemfile.lock, update .gitignore

Starting to do some development on this gem again and needed to have a docker environment and a reliable Gemfile and lock combo. This branch adds all of that and fixes some deprecation warnings so that specs run cleanly.
