### PR TITLE
Fix ActiveJob failure payload corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+* Fix data corruption when retrying ActiveJob failures without clearing them. Stored
+  payloads now retain `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper` and its
+  serialized arguments while the UI still displays and filters by the inner job class.
+* Preserve the wrapper when enqueueing ActiveJob retries, including repeated retries.
+
+ActiveJob failure records already corrupted by an earlier retry cannot be recovered by
+this gem. Check the failed list for records whose `payload.class` is an ActiveJob class
+rather than `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper`.
+
+`cleaner.select` and `/cleaner_dump` now return the original ActiveJob wrapper payload
+instead of a flattened inner class and arguments. Code consuming those results should
+read the raw wrapper shape.
+
 ## 0.4.1 (2018-01-25)
 
 * Remove Requeue version lock (#46)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resque-cleaner (0.4.1)
+    resque-cleaner (0.5.0)
       resque
 
 GEM
@@ -41,6 +41,7 @@ GEM
     timecop (0.9.6)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -52,7 +52,7 @@ module Resque
       def stats_by_class(&block)
         jobs, stats = select(&block), {}
         jobs.each do |job|
-          klass = job["payload"] && job["payload"]["class"] ? job["payload"]["class"] : "UNKNOWN"
+          klass = job.display_class || "UNKNOWN"
           stats[klass] ||= 0
           stats[klass] += 1
         end
@@ -155,6 +155,33 @@ module Resque
 
       # Exntends job(Hash instance) with some helper methods.
       module FailedJobEx
+        ACTIVE_JOB_WRAPPER = "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+
+        def display_class
+          payload = self["payload"]
+          return unless payload.is_a?(Hash)
+
+          if payload["class"] == ACTIVE_JOB_WRAPPER
+            wrapper = active_job_wrapper_payload
+            job_class = wrapper && wrapper["job_class"]
+            job_class.is_a?(String) && !job_class.empty? ? job_class : payload["class"]
+          else
+            payload["class"]
+          end
+        end
+
+        def display_args
+          payload = self["payload"]
+          return unless payload.is_a?(Hash)
+
+          if payload["class"] == ACTIVE_JOB_WRAPPER
+            wrapper = active_job_wrapper_payload
+            wrapper && wrapper.key?("arguments") ? wrapper["arguments"] : payload["args"]
+          else
+            payload["args"]
+          end
+        end
+
         # Returns true if the job has been already retried. Otherwise returns
         # false.
         def retried?
@@ -180,8 +207,8 @@ module Resque
 
         # Returns true if the class of the job matches. Otherwise returns false.
         def klass?(klass_or_name)
-          if self["payload"] && self["payload"]["class"]
-            self["payload"]["class"] == klass_or_name.to_s
+          if display_class
+            display_class == klass_or_name.to_s
           else
             klass_or_name=="UNKNOWN"
           end
@@ -195,6 +222,13 @@ module Resque
         # Returns true if the queue of the job matches. Otherwise returns false.
         def queue?(queue)
           self["queue"] == queue.to_s
+        end
+
+        private
+
+        def active_job_wrapper_payload
+          args = self.dig("payload", "args")
+          args[0] if args.is_a?(Array) && args[0].is_a?(Hash)
         end
       end
 
@@ -251,13 +285,6 @@ module Resque
           jobs = [] unless jobs
           jobs = [jobs] unless jobs.is_a?(Array)
           jobs.each{|j| j.extend FailedJobEx}
-
-          # ActiveJob compatibility layer
-          jobs.each do |job|
-            next unless job.dig("payload", "class") == "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
-            job["payload"]["class"] = job.dig("payload", "args", 0, "job_class")
-            job["payload"]["args"] = job.dig("payload", "args", 0, "arguments")
-          end
           jobs
         end
 

--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -117,8 +117,7 @@ module ResqueCleaner
           @stats = { :klass => {}, :exception => {} }
           @total = Hash.new(0)
           @jobs.each do |job|
-            payload = job["payload"] || {}
-            klass = payload["class"] || 'UNKNOWN'
+            klass = job.display_class || 'UNKNOWN'
             exception = job["exception"] || 'UNKNOWN'
             failed_at = Time.parse job["failed_at"]
             @stats[:klass][klass] ||= Hash.new(0)

--- a/lib/resque_cleaner/server/views/cleaner_list.erb
+++ b/lib/resque_cleaner/server/views/cleaner_list.erb
@@ -89,9 +89,9 @@
               <% end %>
             </dd>
             <dt>Class</dt>
-            <dd><code><%= job['payload'] ? job['payload']['class'] : 'nil' %></code></dd>
+            <dd><code><%= job['payload'] ? job.display_class : 'nil' %></code></dd>
             <dt>Arguments</dt>
-            <dd><pre><%=h job['payload'] ? show_job_args(job['payload']['args']) : 'nil' %></pre></dd>
+            <dd><pre><%=h job['payload'] ? show_job_args(job.display_args) : 'nil' %></pre></dd>
             <dt>Exception</dt>
             <dd><code><%= job['exception'] %></code></dd>
             <dt>Error</dt>

--- a/test/resque_cleaner_test.rb
+++ b/test/resque_cleaner_test.rb
@@ -82,6 +82,97 @@ describe "ResqueCleaner" do
     assert_equal 42, queue_size(:jobs,:jobs2)
   end
 
+  it "#requeue preserves stored ActiveJob payloads and enqueues the wrapper" do
+    Resque.redis.redis.flushall
+    original = activejob_failure_data
+    add_activejob_failure
+
+    assert_equal 1, @cleaner.requeue(false)
+
+    stored = Resque.decode(Resque.redis.lindex(:failed, 0))
+    retried_at = stored.delete("retried_at")
+    assert_match(/\A\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}\z/, retried_at)
+    assert_equal Resque.decode(Resque.encode(original)), stored
+
+    queued = Resque.peek(:queue, 0)
+    assert_equal "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper", queued["class"]
+    assert_equal Resque.decode(Resque.encode(original[:payload][:args])), queued["args"]
+  end
+
+  it "#requeue retries the same ActiveJob failure repeatedly without corruption" do
+    Resque.redis.redis.flushall
+    add_activejob_failure
+
+    2.times { assert_equal 1, @cleaner.requeue(false) }
+
+    first = Resque.peek(:queue, 0)
+    second = Resque.peek(:queue, 1)
+    assert_equal first, second
+    assert_equal "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper", second["class"]
+    assert_equal "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper",
+      Resque.decode(Resque.redis.lindex(:failed, 0)).dig("payload", "class")
+  end
+
+  it "#requeue leaves a plain Resque payload unchanged" do
+    Resque.redis.redis.flushall
+    create_and_process_jobs :jobs, @worker, 1, Time.now, BadJob, "plain"
+    original = Resque.decode(Resque.redis.lindex(:failed, 0))
+
+    assert_equal 1, @cleaner.requeue(false)
+
+    stored = Resque.decode(Resque.redis.lindex(:failed, 0))
+    assert_equal original["payload"], stored["payload"]
+  end
+
+  it "#clear removes ActiveJob failures" do
+    Resque.redis.redis.flushall
+    add_activejob_failure
+
+    assert_equal 1, @cleaner.clear
+    assert_equal 0, @cleaner.failure.count
+  end
+
+  it "display helpers tolerate malformed ActiveJob wrapper arguments" do
+    wrapper = "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+    malformed_args = [
+      [nil, nil],
+      ["invalid", "invalid"],
+      [[123], [123]],
+      [[{}], [{}]],
+      [[{"arguments" => ["raw"]}], ["raw"]]
+    ]
+
+    malformed_args.each do |args, expected_display_args|
+      job = {"payload" => {"class" => wrapper, "args" => args}}
+      job.extend Resque::Plugins::ResqueCleaner::FailedJobEx
+
+      assert_equal wrapper, job.display_class
+      if expected_display_args.nil?
+        assert_nil job.display_args
+      else
+        assert_equal expected_display_args, job.display_args
+      end
+      assert job.klass?(wrapper)
+    end
+  end
+
+  it "display helpers reject malformed ActiveJob class names" do
+    wrapper = "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+
+    [[], {}, 123, false, nil, ""].each do |job_class|
+      job = {
+        "payload" => {
+          "class" => wrapper,
+          "args" => [{"job_class" => job_class, "arguments" => []}]
+        }
+      }
+      job.extend Resque::Plugins::ResqueCleaner::FailedJobEx
+
+      assert_equal wrapper, job.display_class
+      assert job.klass?(wrapper)
+    end
+  end
+
   it "#requeue with a block retries failure jobs which the block evaluates true" do
     requeued = @cleaner.requeue{|job| job["payload"]["args"][0]=="Jason"}
     assert_equal 13, requeued

--- a/test/resque_web_test.rb
+++ b/test/resque_web_test.rb
@@ -42,11 +42,27 @@ describe "resque-web" do
     assert last_response.ok?, last_response.errors
   end
 
-  it '#cleaner_list shows ActiveJob failed jobs properly formated' do
+  it '#cleaner_list filters and displays ActiveJob failures by the inner class' do
     add_activejob_failure
 
+    get "/cleaner"
+    assert last_response.ok?, last_response.errors
+    assert_includes last_response.body, 'ActiveJobGoodJob'
+    refute_includes last_response.body, 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+
     get "/cleaner_list", :c => "ActiveJobGoodJob"
-    assert last_response.body.include?("ActiveJobGoodJob")
+
+    assert last_response.ok?, last_response.errors
+    assert_includes last_response.body, '<option selected="selected" value="ActiveJobGoodJob">ActiveJobGoodJob</option>'
+    assert_includes last_response.body, '<code>ActiveJobGoodJob</code>'
+    assert_includes last_response.body, 'good_job'
+    refute_includes last_response.body, '<code>ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper</code>'
+
+    get "/cleaner_dump", :c => "ActiveJobGoodJob"
+    dumped = JSON.parse(last_response.body)
+    assert_equal 1, dumped.size
+    assert_equal "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper", dumped[0].dig("payload", "class")
+    assert_equal "ActiveJobGoodJob", dumped[0].dig("payload", "args", 0, "job_class")
   end
 
   it '#cleaner_list shows the failed jobs' do
@@ -63,6 +79,34 @@ describe "resque-web" do
   it "#cleaner_list shows escaped XSS attempt" do
     get "/cleaner_list?t=%22%3e%3cscript%3ealert(document.cookie)%3c%2fscript%3e"
     assert last_response.body.include?('&quot;&gt;&lt;script&gt;alert(document.cookie)&lt;&#x2F;script&gt;')
+  end
+
+  it "cleaner pages tolerate malformed ActiveJob wrapper arguments" do
+    data = activejob_failure_data
+    data[:payload][:args] = "invalid"
+    Resque.redis.rpush(:failed, Resque.encode(data))
+
+    get "/cleaner"
+    assert last_response.ok?, last_response.errors
+    assert_includes last_response.body, "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+
+    get "/cleaner_list"
+    assert last_response.ok?, last_response.errors
+    assert_includes last_response.body, "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+  end
+
+  it "cleaner pages tolerate malformed ActiveJob class names" do
+    data = activejob_failure_data
+    data[:payload][:args][0][:job_class] = []
+    Resque.redis.rpush(:failed, Resque.encode(data))
+
+    get "/cleaner"
+    assert last_response.ok?, last_response.errors
+    assert_includes last_response.body, "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+
+    get "/cleaner_list"
+    assert last_response.ok?, last_response.errors
+    assert_includes last_response.body, "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
   end
 
   it '#cleaner_exec clears job' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,7 +131,13 @@ def add_empty_payload_failure
 end
 
 def add_activejob_failure
-  data = {
+  encoded = Resque.encode(activejob_failure_data)
+  Resque.redis.rpush(:failed, encoded)
+  encoded
+end
+
+def activejob_failure_data
+  {
     :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
     :payload   => {
       :class => "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper",
@@ -155,6 +161,4 @@ def add_activejob_failure
     :worker    => "worker",
     :queue     => "queue"
   }
-  data = Resque.encode(data)
-  Resque.redis.rpush(:failed, data)
 end


### PR DESCRIPTION
## Summary

- stop mutating decoded ActiveJob failure payloads during selection
- derive the inner job class and arguments for display, filtering, and statistics
- preserve `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper` and its serialized arguments when retrying, including repeated retries
- safely fall back to the wrapper class for malformed ActiveJob payloads
- add the `aarch64-linux` Bundler platform required by the Docker test environment

## Behavior change

`cleaner.select` and `/cleaner_dump` now return the original ActiveJob wrapper payload instead of the previously flattened inner class and arguments. Consumers of those interfaces should read the raw wrapper shape.

ActiveJob failures already corrupted by an earlier retry cannot be reconstructed by this change.

## Regression coverage

- retry without clearing preserves the stored wrapper payload except for `retried_at`
- retry enqueues `JobWrapper`, and repeated retry remains stable
- class filtering, dropdowns, dashboard statistics, and failure display use the inner class
- `/cleaner_dump` filtering uses the inner class while returning the raw wrapper payload
- malformed wrapper arguments and invalid inner class values fall back without breaking Cleaner pages
- plain Resque retry and ActiveJob clear behavior remain unchanged

## Verification

- `docker compose run --rm console bundle exec rake test` — 35 runs, 134 assertions, 0 failures
- Ruby syntax checks for `lib/resque_cleaner.rb` and `lib/resque_cleaner/server.rb`
- `git diff --check`
