### PR TITLE
Fix exact removal of duplicate failure records

### DIFF
--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'securerandom'
 require 'resque'
 require 'resque/server'
 
@@ -103,10 +104,7 @@ module Resque
           @limiter.jobs.each_with_index do |job,i|
             if !block_given? || block.call(job)
               index = @limiter.start_index + i - cleared
-              # fetches again since you can't ensure that it is always true:
-              # a == endode(decode(a))
-              value = redis.lindex(:failed, index)
-              redis.lrem(:failed, 1, value)
+              remove_failure_at(index)
               cleared += 1
             end
           end
@@ -123,19 +121,13 @@ module Resque
             if !block_given? || block.call(job)
               index = @limiter.start_index + i - requeued
 
-              value = redis.lindex(:failed, index)
-              redis.multi do
-                Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
+              Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
 
-                if clear_after_requeue
-                  # remove job
-                  # TODO: should use ltrim. not sure why i used lrem here...
-                  redis.lrem(:failed, 1, value)
-                else
-                  # mark retried
-                  job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
-                  redis.lset(:failed, @limiter.start_index+i, Resque.encode(job))
-                end
+              if clear_after_requeue
+                remove_failure_at(index)
+              else
+                job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
+                redis.lset(:failed, @limiter.start_index+i, Resque.encode(job))
               end
 
               requeued += 1
@@ -305,6 +297,16 @@ module Resque
 
       def too_many_message
         "There are too many failed jobs(count=#{@failure.count}). This only looks at last #{@limiter.maximum} jobs."
+      end
+
+      private
+
+      def remove_failure_at(index)
+        sentinel = SecureRandom.uuid
+        redis.multi do |transaction|
+          transaction.lset(:failed, index, sentinel)
+          transaction.lrem(:failed, 1, sentinel)
+        end
       end
     end
   end

--- a/test/resque_cleaner_test.rb
+++ b/test/resque_cleaner_test.rb
@@ -74,6 +74,19 @@ describe "ResqueCleaner" do
     assert_equal 0, @cleaner.select{|job| job["payload"]["args"][0]=="Jason"}.size
   end
 
+  it "#clear removes the selected byte-identical failure" do
+    encoded = Resque.redis.lindex(:failed, 0)
+    marker_data = Resque.decode(encoded)
+    marker_data["exception"] = "DistinctFailure"
+    marker = Resque.encode(marker_data)
+    Resque.redis.redis.flushall
+    [encoded, marker, encoded].each { |value| Resque.redis.rpush(:failed, value) }
+    @cleaner.limiter.maximum = 1
+
+    assert_equal 1, @cleaner.clear
+    assert_equal [encoded, marker], Resque.redis.lrange(:failed, 0, -1)
+  end
+
   it "#requeue retries failure jobs" do
     assert_equal 0, queue_size(:jobs,:jobs2)
     requeued = @cleaner.requeue
@@ -94,6 +107,20 @@ describe "ResqueCleaner" do
     assert_equal 42, requeued
     assert_equal 42, queue_size(:jobs,:jobs2)
     assert_equal 0, @cleaner.select.size
+  end
+
+  it "#requeue with clear removes the selected byte-identical failure" do
+    encoded = Resque.redis.lindex(:failed, 0)
+    marker_data = Resque.decode(encoded)
+    marker_data["exception"] = "DistinctFailure"
+    marker = Resque.encode(marker_data)
+    Resque.redis.redis.flushall
+    [encoded, marker, encoded].each { |value| Resque.redis.rpush(:failed, value) }
+    @cleaner.limiter.maximum = 1
+
+    assert_equal 1, @cleaner.requeue(true)
+    assert_equal [encoded, marker], Resque.redis.lrange(:failed, 0, -1)
+    assert_equal "BadJob", Resque.peek(:jobs, 0)["class"]
   end
 
   it "#requeue with :queue option requeues the jobs to the queue" do


### PR DESCRIPTION
## Summary

- remove failed jobs by the selected Redis list index rather than by serialized value
- replace the selected entry with a unique sentinel and remove that sentinel in a real Redis transaction
- remove the ineffective outer `redis.multi` block, which did not use the transaction object

## Why

`LREM` removes by value. If two failure records are byte-identical, the previous `LINDEX` + `LREM 1 value` sequence can remove a neighboring record instead of the selected row.

## Regression coverage

- selective clear removes the selected duplicate while preserving an identical neighbor
- retry-and-clear removes the selected duplicate and still enqueues the job

## Verification

- `docker compose run --rm console bundle exec rake test` — 29 runs, 69 assertions, 0 failures
- `docker compose run --rm console bundle exec ruby -c lib/resque_cleaner.rb`
- `git diff --check`
