### PR TITLE
Escape persisted failure metadata in Cleaner UI

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -84,7 +84,8 @@ module ResqueCleaner
             html += "<option value=\"\">-</option>"
             klasses.each do |k|
               selected = k == value ? 'selected="selected"' : ''
-              html += "<option #{selected} value=\"#{k}\">#{k}</option>"
+              escaped = Rack::Utils.escape_html(k.to_s)
+              html += "<option #{selected} value=\"#{escaped}\">#{escaped}</option>"
             end
             html += "</select>"
           end
@@ -94,7 +95,8 @@ module ResqueCleaner
             html += "<option value=\"\">-</option>"
             exceptions.each do |ex|
               selected = ex == value ? 'selected="selected"' : ''
-              html += "<option #{selected} value=\"#{ex}\">#{ex}</option>"
+              escaped = Rack::Utils.escape_html(ex.to_s)
+              html += "<option #{selected} value=\"#{escaped}\">#{escaped}</option>"
             end
             html += "</select>"
           end

--- a/lib/resque_cleaner/server/views/_stats.erb
+++ b/lib/resque_cleaner/server/views/_stats.erb
@@ -11,7 +11,7 @@
   <% @stats[type.to_sym].each do |field,count| %>
     <tr>
       <% filter = "#{q}=#{CGI.escape(field)}" %>
-      <td><%= field %></td>
+      <td><%=h field %></td>
       <td class="number">
         <a href="cleaner_list?<%=filter%>"><%= count[:total] %></a>
       </td>

--- a/lib/resque_cleaner/server/views/cleaner_list.erb
+++ b/lib/resque_cleaner/server/views/cleaner_list.erb
@@ -81,19 +81,19 @@
             <dd>&nbsp;</dd>
             <dt>Worker</dt>
             <dd>
-              <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= Time.parse(job['failed_at']).strftime(date_format) %></span></b>
+              <a href="<%=h u(:workers, job['worker']) %>"><%=h job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%=h job['queue'] %></b > at <b><span class="time"><%= Time.parse(job['failed_at']).strftime(date_format) %></span></b>
               <% if job['retried_at'] %>
                 <div class='retried'>
-                  Retried <b><span class="time"><%= job['retried_at'] %></span></b>
+                  Retried <b><span class="time"><%=h job['retried_at'] %></span></b>
                 </div>
               <% end %>
             </dd>
             <dt>Class</dt>
-            <dd><code><%= job['payload'] ? job.display_class : 'nil' %></code></dd>
+            <dd><code><%=h job['payload'] ? job.display_class : 'nil' %></code></dd>
             <dt>Arguments</dt>
             <dd><pre><%=h job['payload'] ? show_job_args(job.display_args) : 'nil' %></pre></dd>
             <dt>Exception</dt>
-            <dd><code><%= job['exception'] %></code></dd>
+            <dd><code><%=h job['exception'] %></code></dd>
             <dt>Error</dt>
             <dd class='error'>
               <% if job['backtrace'] %>

--- a/test/resque_web_test.rb
+++ b/test/resque_web_test.rb
@@ -109,6 +109,32 @@ describe "resque-web" do
     assert_includes last_response.body, "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
   end
 
+  it "escapes persisted failure values" do
+    data = activejob_failure_data
+    data[:payload][:args][0][:job_class] = %q{"><script>alert(1)</script>}
+    data[:exception] = %q{"><script>alert(2)</script>}
+    data[:worker] = %q{worker"><script>alert(3)</script>:123:queue}
+    data[:queue] = %q{"><script>alert(4)</script>}
+    data[:retried_at] = %q{"><script>alert(5)</script>}
+    Resque.redis.rpush(:failed, Resque.encode(data))
+
+    get "/cleaner"
+    assert_includes last_response.body, '&quot;&gt;&lt;script&gt;alert(1)&lt;&#x2F;script&gt;'
+    assert_includes last_response.body, '&quot;&gt;&lt;script&gt;alert(2)&lt;&#x2F;script&gt;'
+    refute_includes last_response.body, '<script>alert(1)</script>'
+    refute_includes last_response.body, '<script>alert(2)</script>'
+
+    get "/cleaner_list"
+    assert_includes last_response.body, '&quot;&gt;&lt;script&gt;alert(1)&lt;&#x2F;script&gt;'
+    assert_includes last_response.body, '&quot;&gt;&lt;script&gt;alert(2)&lt;&#x2F;script&gt;'
+    assert_includes last_response.body, 'worker&quot;&gt;&lt;script&gt;alert(3)&lt;&#x2F;script&gt;:123'
+    assert_includes last_response.body, '&quot;&gt;&lt;script&gt;alert(4)&lt;&#x2F;script&gt;'
+    assert_includes last_response.body, '&quot;&gt;&lt;script&gt;alert(5)&lt;&#x2F;script&gt;'
+    (1..5).each do |number|
+      refute_includes last_response.body, "<script>alert(#{number})</script>"
+    end
+  end
+
   it '#cleaner_exec clears job' do
     post "/cleaner_exec", :action => "clear", :sha1 => Digest::SHA1.hexdigest(@cleaner.select[0].to_json)
     assert_equal 10, @cleaner.select.size


### PR DESCRIPTION
## Summary

- escape persisted ActiveJob display class and exception values in Cleaner filters, statistics, and failure rows
- escape worker, queue, and `retried_at` values in failure rows, including the worker link attribute
- add regression coverage using an ActiveJob wrapper so the test distinguishes `display_class` from the outer payload class

## Why

Failure metadata is persisted external input. Rendering it without HTML escaping allows stored markup or script injection in the Cleaner UI.

## Rebase resolution

This branch is rebased on the merged ActiveJob and exact-index fixes. The class conflict is resolved by retaining the ActiveJob-aware value and applying escaping:

```erb
<dd><code><%=h job['payload'] ? job.display_class : 'nil' %></code></dd>
```

## Verification

- `docker compose run --rm console bundle exec rake test` — 38 runs, 167 assertions, 0 failures
- Ruby syntax checks for `lib/resque_cleaner.rb` and `lib/resque_cleaner/server.rb`
- `git diff --check upstream/master...HEAD`
