### PR TITLE
Load Cleaner server dependencies directly

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -1,4 +1,6 @@
 require 'yaml'
+require 'digest/sha1'
+require 'json'
 
 # Extends Resque Web Based UI.
 # Structure has been borrowed from ResqueScheduler.
@@ -110,7 +112,6 @@ module ResqueCleaner
         mime_type :json, 'application/json'
 
         get "/cleaner" do
-          load_library
           load_cleaner_filter
 
           @jobs = cleaner.select
@@ -142,7 +143,6 @@ module ResqueCleaner
         end
 
         get "/cleaner_list" do
-          load_library
           load_cleaner_filter
           build_urls
 
@@ -160,7 +160,6 @@ module ResqueCleaner
         end
 
         post "/cleaner_exec" do
-          load_library
           load_cleaner_filter
           build_urls
 
@@ -182,7 +181,6 @@ module ResqueCleaner
         end
 
         get "/cleaner_dump" do
-          load_library
           load_cleaner_filter
 
           block = filter_block
@@ -192,7 +190,6 @@ module ResqueCleaner
         end
 
         post "/cleaner_stale" do
-          load_library
           cleaner.clear_stale
           redirect url_path(:cleaner)
         end
@@ -204,15 +201,6 @@ module ResqueCleaner
       @cleaner ||= Resque::Plugins::ResqueCleaner.new
       @cleaner.print_message = false
       @cleaner
-    end
-
-    def load_library
-      require 'digest/sha1'
-      begin
-        require 'yajl/json_gem' unless [].respond_to?(:to_json)
-      rescue Exception
-        require 'json'
-      end
     end
 
     def load_cleaner_filter


### PR DESCRIPTION
## Summary

- require `digest/sha1` and `json` when the Cleaner server extension loads
- remove the route-level `load_library` calls and compatibility helper

## Why

These are standard-library dependencies used by the extension. Loading them directly is simpler and avoids repeating dependency setup on every Cleaner route.

## Verification

- `docker compose run --rm console bundle exec rake test` — 27 runs, 64 assertions, 0 failures
- `docker compose run --rm console bundle exec ruby -c lib/resque_cleaner/server.rb`
- `git diff --check`
