### PR TITLE
Version 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
-## Unreleased
+## 0.5.1 (2026-07-30)
 
 * Fix data corruption when retrying ActiveJob failures without clearing them. Stored
   payloads now retain `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper` and its
   serialized arguments while the UI still displays and filters by the inner job class.
 * Preserve the wrapper when enqueueing ActiveJob retries, including repeated retries.
+* Remove failed-list entries by list index, replacing the selected entry with a unique
+  sentinel inside a Redis transaction. Byte-identical failure records can no longer
+  cause the wrong entry to be removed. Replaces a `redis.multi` block that never used
+  the transaction object and so was not atomic.
+* Escape persisted failure metadata rendered in the Cleaner web UI: job class,
+  exception, worker, queue, and `retried_at`.
+* Require `digest/sha1` and `json` when the server extension loads rather than on every
+  Cleaner route, and drop the obsolete `yajl/json_gem` fallback.
 
 ActiveJob failure records already corrupted by an earlier retry cannot be recovered by
 this gem. Check the failed list for records whose `payload.class` is an ActiveJob class
@@ -12,6 +20,15 @@ rather than `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper`.
 `cleaner.select` and `/cleaner_dump` now return the original ActiveJob wrapper payload
 instead of a flattened inner class and arguments. Code consuming those results should
 read the raw wrapper shape.
+
+## 0.5.0 (2023-04-20)
+
+* Ruby 3+ support, including a fix for rendering the Cleaner page.
+* Display ActiveJob failures using the inner job class rather than the queue adapter
+  wrapper.
+* Escape job arguments rendered in the web UI.
+* Fix redis-namespace deprecation warnings.
+* Add a Docker-based test environment.
 
 ## 0.4.1 (2018-01-25)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resque-cleaner (0.5.0)
+    resque-cleaner (0.5.1)
       resque
 
 GEM

--- a/resque-cleaner.gemspec
+++ b/resque-cleaner.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "resque-cleaner"
-  s.version           = "0.5.0"
+  s.version           = "0.5.1"
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "Resque plugin cleaning up failed jobs."
   s.homepage          = "https://github.com/ono/resque-cleaner"


### PR DESCRIPTION
Release prep for 0.5.1. No functional changes — version, lockfile, and changelog only.

## Changes

- `resque-cleaner.gemspec` — version `0.5.0` → `0.5.1`
- `Gemfile.lock` — `resque-cleaner (0.5.0)` → `(0.5.1)`
- `CHANGELOG.md` — promote the `## Unreleased` section to `## 0.5.1 (2026-07-30)` and fill in the entries for the other three fixes that landed alongside it (#3, #4, #5), which weren't covered by the original Unreleased block

## Backfilled 0.5.0 entry

0.5.0 shipped in April 2023 with no changelog entry, so this also adds one, reconstructed from the commits between `v0.4.1` and `216779f`:

- Ruby 3+ support, including the Cleaner page rendering fix
- ActiveJob failures displayed by inner job class
- Job arguments escaped in the web UI
- redis-namespace deprecation warnings
- Docker-based test environment

Drop that section if you'd rather leave 0.5.0 undocumented.

## Tags

`v0.5.0` has been tagged at `216779f` (annotated, backdated to the original commit date), matching the upstream `v0.4.1`/`v0.4.0` naming. `v0.5.1` will be tagged on the merge commit once this lands.

## Verification

Run against this branch:

- `bundle exec rake test` — 38 runs, 167 assertions, 0 failures
- `bundle check` — dependencies satisfied with the bumped lockfile
- `gem build resque-cleaner.gemspec` — builds `resque-cleaner-0.5.1.gem`

Not published to RubyGems.